### PR TITLE
Fixing docx and pptx translation

### DIFF
--- a/argostranslatefiles/argostranslatefiles.py
+++ b/argostranslatefiles/argostranslatefiles.py
@@ -12,12 +12,12 @@ from argostranslatefiles.formats.epub import Epub
 def get_supported_formats():
     return [
         Txt(),
-        #Odt(),
-        #Odp(),
+        Odt(),
+        Odp(),
         Docx(),
         Pptx()
-        #Epub(),
-        #Html()
+        Epub(),
+        Html()
     ]
 
 

--- a/argostranslatefiles/argostranslatefiles.py
+++ b/argostranslatefiles/argostranslatefiles.py
@@ -15,7 +15,7 @@ def get_supported_formats():
         Odt(),
         Odp(),
         Docx(),
-        Pptx()
+        Pptx(),
         Epub(),
         Html()
     ]

--- a/argostranslatefiles/argostranslatefiles.py
+++ b/argostranslatefiles/argostranslatefiles.py
@@ -12,12 +12,12 @@ from argostranslatefiles.formats.epub import Epub
 def get_supported_formats():
     return [
         Txt(),
-        Odt(),
-        Odp(),
+        #Odt(),
+        #Odp(),
         Docx(),
-        Pptx(),
-        Epub(),
-        Html()
+        Pptx()
+        #Epub(),
+        #Html()
     ]
 
 

--- a/argostranslatefiles/formats/openxml/docx.py
+++ b/argostranslatefiles/formats/openxml/docx.py
@@ -10,7 +10,6 @@ class Docx(AbstractXml):
 
     def translate_paragraphs(self,paragraphs,underlying_translation):
         for paragraph in paragraphs:
-            sys.stderr.write(f'{paragraph.text}\n')
 
             if len(paragraph.runs) == 1:
                 paragraph.runs[0].text = underlying_translation.translate(paragraph.runs[0].text)
@@ -20,7 +19,6 @@ class Docx(AbstractXml):
                 first_run_style = paragraph.runs[0].style
                 #get the dominant run in the paragraph
                 dominant_run = max(paragraph.runs, key=lambda x: len(x.text))
-                sys.stderr.write(f'dominant run: {dominant_run.text}.\n')
                 dom_font = dominant_run.font.name
                 dom_bold = dominant_run.font.bold
                 dom_italic = dominant_run.font.italic

--- a/argostranslatefiles/formats/openxml/docx.py
+++ b/argostranslatefiles/formats/openxml/docx.py
@@ -1,25 +1,49 @@
 from argostranslate.tags import translate_tags
 from argostranslate.translate import ITranslation
 from docx import Document
-
+import sys
 from argostranslatefiles.formats.abstract_xml import AbstractXml
 
 
 class Docx(AbstractXml):
     supported_file_extensions = ['.docx']
 
-    def translate(self, underlying_translation: ITranslation, file_path: str):
-        outzip_path = self.get_output_path(underlying_translation, file_path)
-        document = Document(file_path)
-        for paragraph in document.paragraphs:
+    def translate_paragraphs(self,paragraphs,underlying_translation):
+        for paragraph in paragraphs:
+            sys.stderr.write(f'{paragraph.text}\n')
+
             if len(paragraph.runs) == 1:
                 paragraph.runs[0].text = underlying_translation.translate(paragraph.runs[0].text)
             elif len(paragraph.runs) == 0:
                 continue
             else:
                 first_run_style = paragraph.runs[0].style
+                #get the dominant run in the paragraph
+                dominant_run = max(paragraph.runs, key=lambda x: len(x.text))
+                sys.stderr.write(f'dominant run: {dominant_run.text}.\n')
+                dom_font = dominant_run.font.name
+                dom_bold = dominant_run.font.bold
+                dom_italic = dominant_run.font.italic
+                dom_underline = dominant_run.font.underline
+
                 paragraph.text = underlying_translation.translate(paragraph.text)
-                paragraph.runs[0].style = first_run_style
+                paragraph.runs[0].font.name = dom_font
+                paragraph.runs[0].font.bold = dom_bold
+                paragraph.runs[0].font.italic = dom_italic
+                paragraph.runs[0].font.underline = dom_underline
+
+
+
+    def translate(self, underlying_translation: ITranslation, file_path: str):
+        outzip_path = self.get_output_path(underlying_translation, file_path)
+        document = Document(file_path)
+
+        self.translate_paragraphs(document.paragraphs,underlying_translation)
+        
+        for table in document.tables:
+            for row in table.rows:
+                for cell in row.cells:
+                    self.translate_paragraphs(cell.paragraphs,underlying_translation)
 
         document.save(outzip_path)
 

--- a/argostranslatefiles/formats/openxml/docx.py
+++ b/argostranslatefiles/formats/openxml/docx.py
@@ -1,8 +1,6 @@
-import zipfile
-
 from argostranslate.tags import translate_tags
 from argostranslate.translate import ITranslation
-from bs4 import BeautifulSoup
+from docx import Document
 
 from argostranslatefiles.formats.abstract_xml import AbstractXml
 
@@ -12,24 +10,17 @@ class Docx(AbstractXml):
 
     def translate(self, underlying_translation: ITranslation, file_path: str):
         outzip_path = self.get_output_path(underlying_translation, file_path)
+        document = Document(file_path)
+        for paragraph in document.paragraphs:
+            if len(paragraph.runs) == 1:
+                paragraph.runs[0].text = underlying_translation.translate(paragraph.runs[0].text)
+            elif len(paragraph.runs) == 0:
+                continue
+            else:
+                first_run_style = paragraph.runs[0].style
+                paragraph.text = underlying_translation.translate(paragraph.text)
+                paragraph.runs[0].style = first_run_style
 
-        inzip = zipfile.ZipFile(file_path, "r")
-        outzip = zipfile.ZipFile(outzip_path, "w")
-
-        for inzipinfo in inzip.infolist():
-            with inzip.open(inzipinfo) as infile:
-                if inzipinfo.filename == "word/document.xml":
-                    soup = BeautifulSoup(infile.read(), 'xml')
-
-                    itag = self.itag_of_soup(soup)
-                    translated_tag = translate_tags(underlying_translation, itag)
-                    translated_soup = self.soup_of_itag(translated_tag)
-
-                    outzip.writestr(inzipinfo.filename, str(translated_soup))
-                else:
-                    outzip.writestr(inzipinfo.filename, infile.read())
-
-        inzip.close()
-        outzip.close()
+        document.save(outzip_path)
 
         return outzip_path

--- a/argostranslatefiles/formats/openxml/pptx.py
+++ b/argostranslatefiles/formats/openxml/pptx.py
@@ -1,11 +1,17 @@
 from argostranslate.translate import ITranslation
 from pptx import Presentation
+from pptx.chart.data import CategoryChartData,BubbleChartData,XyChartData, XySeriesData
+from pptx.enum.chart import XL_CHART_TYPE
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+
 import sys
 from argostranslatefiles.formats.abstract_xml import AbstractXml
 
 
 class Pptx(AbstractXml):
     supported_file_extensions = ['.pptx']
+    bubble_chart_types = [XL_CHART_TYPE.BUBBLE, XL_CHART_TYPE.BUBBLE_THREE_D_EFFECT]
+    xy_chart_types = [XL_CHART_TYPE.XY_SCATTER,XL_CHART_TYPE.XY_SCATTER_LINES,XL_CHART_TYPE.XY_SCATTER_LINES_NO_MARKERS,XL_CHART_TYPE.XY_SCATTER_SMOOTH,XL_CHART_TYPE.XY_SCATTER_SMOOTH_NO_MARKERS]
 
     def translate_paragraphs(self, paras, underlying_translation):
         for paragraph in paras:
@@ -19,22 +25,51 @@ class Pptx(AbstractXml):
                     if most_common_font_size:
                         paragraph.font.size = most_common_font_size[0]
                 paragraph.text = underlying_translation.translate(paragraph.text)
-         
+
+    def process_shape(self, shape, underlying_translation):
+        if shape.has_text_frame:
+            self.translate_paragraphs(shape.text_frame.paragraphs, underlying_translation)
+    
+        if shape.has_table:
+            for row in shape.table.rows:
+                for cell in row.cells:
+                    self.translate_paragraphs(cell.text_frame.paragraphs, underlying_translation)
+        if shape.has_chart:
+            chart = shape.chart
+        
+            if chart.has_title: 
+                if chart.chart_title.has_text_frame:
+                    self.translate_paragraphs(chart.chart_title.text_frame.paragraphs, underlying_translation)
+            # TODO: Bubble and Xy charts are parsed differently, not clear how to retrieve values
+            if chart.chart_type in self.bubble_chart_types:
+                new_chart_data = BubbleChartData()
+                return
+            elif chart.chart_type in self.xy_chart_types:
+                new_chart_data = XyChartData()
+                return
+            else:
+                new_chart_data = CategoryChartData()
+            new_categories = [underlying_translation.translate(c) for c in chart.plots[0].categories]
+            new_chart_data.categories = new_categories
+            for series in chart.series:
+                new_chart_data.add_series(underlying_translation.translate(series.name),series.values)
+            chart.replace_data(new_chart_data)
+
+            # TODO: Add SmartArt handling here. Pypptx does not support SmartArt, but it might be
+            # possible to first convert SmartArt to shapes by some means. Another alternative is just
+            # to parse the xml to find things that look like text
+
     def translate(self, underlying_translation: ITranslation, file_path: str):
         outzip_path = self.get_output_path(underlying_translation, file_path)
         presentation = Presentation(file_path)
         
         for slide in presentation.slides:
             for shape in slide.shapes:
-                if shape.has_text_frame:
-                    self.translate_paragraphs(shape.text_frame.paragraphs, underlying_translation)
-            
-                if shape.has_table:
-                    for row in shape.table.rows:
-                        for cell in row.cells:
-                            self.translate_paragraphs(cell.text_frame.paragraphs, underlying_translation)
-                            #sys.stderr.write(f"paragraph font size: {paragraph.font.size}. font sizes: {str(font_sizes)}\n")
-                            #c.text = underlying_translation.translate(c.text)
+                if shape.shape_type == MSO_SHAPE_TYPE.GROUP:
+                    for subshape in shape.shapes:
+                        self.process_shape(subshape, underlying_translation)
+                else:
+                    self.process_shape(shape, underlying_translation)
 
         presentation.save(outzip_path)  
 

--- a/argostranslatefiles/formats/openxml/pptx.py
+++ b/argostranslatefiles/formats/openxml/pptx.py
@@ -1,23 +1,30 @@
 from argostranslate.translate import ITranslation
 from pptx import Presentation
-
+import sys
 from argostranslatefiles.formats.abstract_xml import AbstractXml
 
 
 class Pptx(AbstractXml):
     supported_file_extensions = ['.pptx']
 
+    def translate_paragraphs(self, paras, underlying_translation):
+        for paragraph in paras:
+            paragraph.text = underlying_translation.translate(paragraph.text)
+        
     def translate(self, underlying_translation: ITranslation, file_path: str):
         outzip_path = self.get_output_path(underlying_translation, file_path)
         presentation = Presentation(file_path)
         
         for slide in presentation.slides:
             for shape in slide.shapes:
-                if not shape.has_text_frame:
-                    continue
-                for paragraph in shape.text_frame.paragraphs:
-                    paragraph.text = underlying_translation.translate(paragraph.text)
-       
+                if shape.has_text_frame:
+                    self.translate_paragraphs(shape.text_frame.paragraphs, underlying_translation)
+            
+                if shape.has_table:
+                    for r in shape.table.rows:
+                        for c in r.cells:
+                            c.text = underlying_translation.translate(c.text)
+
         presentation.save(outzip_path)  
 
 

--- a/argostranslatefiles/formats/openxml/pptx.py
+++ b/argostranslatefiles/formats/openxml/pptx.py
@@ -9,8 +9,17 @@ class Pptx(AbstractXml):
 
     def translate_paragraphs(self, paras, underlying_translation):
         for paragraph in paras:
-            paragraph.text = underlying_translation.translate(paragraph.text)
-        
+            #get the average font size for the para
+            if paragraph.runs:
+                font_sizes = [(x.font.size,len(x.text)) for x in paragraph.runs]
+                #sys.stderr.write(f"paragraph font size: {paragraph.font.size}. font sizes: {str(font_sizes)}\n")
+                if font_sizes:
+                    #avg_font_size = round(sum([x[0] for x in font_sizes])/len([x[0] for x in font_sizes]))
+                    most_common_font_size = sorted(font_sizes,key=lambda x: x[1])[0]
+                    if most_common_font_size:
+                        paragraph.font.size = most_common_font_size[0]
+                paragraph.text = underlying_translation.translate(paragraph.text)
+         
     def translate(self, underlying_translation: ITranslation, file_path: str):
         outzip_path = self.get_output_path(underlying_translation, file_path)
         presentation = Presentation(file_path)
@@ -21,9 +30,11 @@ class Pptx(AbstractXml):
                     self.translate_paragraphs(shape.text_frame.paragraphs, underlying_translation)
             
                 if shape.has_table:
-                    for r in shape.table.rows:
-                        for c in r.cells:
-                            c.text = underlying_translation.translate(c.text)
+                    for row in shape.table.rows:
+                        for cell in row.cells:
+                            self.translate_paragraphs(cell.text_frame.paragraphs, underlying_translation)
+                            #sys.stderr.write(f"paragraph font size: {paragraph.font.size}. font sizes: {str(font_sizes)}\n")
+                            #c.text = underlying_translation.translate(c.text)
 
         presentation.save(outzip_path)  
 

--- a/argostranslatefiles/formats/openxml/pptx.py
+++ b/argostranslatefiles/formats/openxml/pptx.py
@@ -1,9 +1,5 @@
-import re
-import zipfile
-
-from argostranslate.tags import translate_tags
 from argostranslate.translate import ITranslation
-from bs4 import BeautifulSoup
+from pptx import Presentation
 
 from argostranslatefiles.formats.abstract_xml import AbstractXml
 
@@ -13,24 +9,16 @@ class Pptx(AbstractXml):
 
     def translate(self, underlying_translation: ITranslation, file_path: str):
         outzip_path = self.get_output_path(underlying_translation, file_path)
+        presentation = Presentation(file_path)
+        
+        for slide in presentation.slides:
+            for shape in slide.shapes:
+                if not shape.has_text_frame:
+                    continue
+                for paragraph in shape.text_frame.paragraphs:
+                    paragraph.text = underlying_translation.translate(paragraph.text)
+       
+        presentation.save(outzip_path)  
 
-        inzip = zipfile.ZipFile(file_path, "r")
-        outzip = zipfile.ZipFile(outzip_path, "w")
-
-        for inzipinfo in inzip.infolist():
-            with inzip.open(inzipinfo) as infile:
-                if re.match(r"ppt\/slides\/slide[0-9]*\.xml", inzipinfo.filename):
-                    soup = BeautifulSoup(infile.read(), 'xml')
-
-                    itag = self.itag_of_soup(soup)
-                    translated_tag = translate_tags(underlying_translation, itag)
-                    translated_soup = self.soup_of_itag(translated_tag)
-
-                    outzip.writestr(inzipinfo.filename, str(translated_soup))
-                else:
-                    outzip.writestr(inzipinfo.filename, infile.read())
-
-        inzip.close()
-        outzip.close()
 
         return outzip_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ beautifulsoup4>=4.9.3
 lxml>=4.9.2
 argostranslate>=1.5.1
 translatehtml>=1.5.1
+python-pptx>=0.6.21
+python-docx>=0.8.11


### PR DESCRIPTION
Hi,

Thanks for all your work with this repo, it's great and saved me a lot of time. There is major issue though with the way the docx and pptx translation handled: currently each separate run in docs is translated separately, and this means that the machine translations are disjointed. I'll demonstrate with this small example:

If my document contains the formatted text **The** dogs _walk_, each word will be translated separately, resulting for instance in the Finnish translation _The Koirat Kävely kävely kävely kävely_. The correct Finnish translation would be _Koirat kävelevät_. The problem is that each formatted section is a run, and the code extracts them separately. So to take a more realistic example, if there is for instance a single bolded word in a sentence, as in _Click **Open** to open file_, the strings _Click,_ _Open,_ and _to open file_ will be translated independently and the translation stitched together from incompatible parts.

Replicating the formatting when machine translating is not an easy problem, it usually requires aligning the source and target sentences, but I've implemented a simple fix for docx and pptx file types, since I needed to use them in a project of mine. In this fix, I use the pydocx and pypptx modules to extract the text of paragraphs instead of runs, and then translate the paragraphs. The formatting is partially restored by applying the dominant formatting present in the source text (i.e. if the source sentence is mostly bold, the translation will also be bold).

-Tommi
